### PR TITLE
Add color-scheme meta tag for responsive dark mode

### DIFF
--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="color-scheme" content="light dark" />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
     <title>Are The Types Wrong? - Tool for analyzing TypeScript types of npm packages</title>
     <script type="module" src="./main.ts"></script>


### PR DESCRIPTION
This adds responsive light or dark styling to various HTML elements natively. Currently this affects the button, file input, and scroll bars.

Technically it would now be possible to remove some dark mode related CSS.