### PR TITLE
Fix node-fetch dependency missing from @arethetypeswrong/cli

### DIFF
--- a/.changeset/old-numbers-shave.md
+++ b/.changeset/old-numbers-shave.md
@@ -1,0 +1,5 @@
+---
+"@arethetypeswrong/cli": patch
+---
+
+Fix node-fetch dependency missing from @arethetypeswrong/cli

--- a/package-lock.json
+++ b/package-lock.json
@@ -6912,15 +6912,16 @@
     },
     "packages/cli": {
       "name": "@arethetypeswrong/cli",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@arethetypeswrong/core": "0.6.0",
+        "@arethetypeswrong/core": "0.7.0",
         "chalk": "^4.1.2",
         "cli-table3": "^0.6.3",
         "commander": "^10.0.1",
         "marked": "^5.1.0",
-        "marked-terminal": "^5.2.0"
+        "marked-terminal": "^5.2.0",
+        "node-fetch": "^2.6.4"
       },
       "bin": {
         "attw": "dist/index.js"
@@ -6940,7 +6941,7 @@
     },
     "packages/core": {
       "name": "@arethetypeswrong/core",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@andrewbranch/untar.js": "^1.0.0",
@@ -6964,7 +6965,7 @@
     },
     "packages/history": {
       "name": "@arethetypeswrong/history",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "devDependencies": {
         "@arethetypeswrong/core": "file:../core",
         "@azure/storage-blob": "^12.14.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,6 +50,7 @@
     "cli-table3": "^0.6.3",
     "commander": "^10.0.1",
     "marked": "^5.1.0",
-    "marked-terminal": "^5.2.0"
+    "marked-terminal": "^5.2.0",
+    "node-fetch": "^2.6.4"
   }
 }


### PR DESCRIPTION
In #49 dependency on node-fetch was introduced, but this dependency was not added. Consequently, the CLI stopped working on environments with node-fetch unavailable.