### PR TITLE
feat: add open graph meta tags

### DIFF
--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -6,6 +6,17 @@
     <meta name="color-scheme" content="light dark" />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
     <title>Are The Types Wrong? - Tool for analyzing TypeScript types of npm packages</title>
+    <meta name="description" content="Are The Types Wrong? - Tool for analyzing TypeScript types of npm packages" />
+
+    <!-- Open Graph Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:creator" content="@atcb" />
+    <meta property="og:url" content="https://arethetypeswrong.github.io/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Are The Types Wrong?" />
+    <meta property="og:description" content="Tool for analyzing TypeScript types of npm packages" />
+    <meta property="og:image" content="https://arethetypeswrong.github.io/icons/android-chrome-512x512.png" />
+
     <script type="module" src="./main.ts"></script>
     <link rel="stylesheet" href="./main.css" />
     <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png" />


### PR DESCRIPTION
First things first: you don't need this.  But I really like Open Graph meta tags as a way to make it easier for others to see what is in a site without having to have browsed there first.  [I've written a little about it](https://johnnyreilly.com/open-graph-sharing-previews-guide)

This PR adds Open Graph meta tags to the arethetypeswrong site.  It's a nicety - it doesn't change the world, but I got to thinking about this when I tweeted this: https://twitter.com/johnny_reilly/status/1695390690362966136 and saw that it was just a link.

With this PR, that link would become a little richer. The following sites can be used to examine whether a site has open graph support at the moment:

- https://www.opengraph.xyz/
- https://metatags.io/
- https://socialsharepreview.com/

But as I say, you don't need this; feel free to not take it!