### PR TITLE
fix: expose type info from @arethetypeswrong/core

### DIFF
--- a/.changeset/tricky-squids-smash.md
+++ b/.changeset/tricky-squids-smash.md
@@ -1,0 +1,5 @@
+---
+"@arethetypeswrong/core": minor
+---
+
+expose type info

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,22 +27,36 @@
   "imports": {
     "#internal/*": "./dist/internal/*"
   },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "development": "./src/index.ts",
-      "default": "./dist/index.js"
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     },
     "./types": {
       "development": "./src/types.ts",
-      "default": "./dist/types.js"
+      "default": {
+        "types": "./dist/types.d.ts",
+        "default": "./dist/types.js"
+      }
     },
     "./utils": {
       "development": "./src/utils.ts",
-      "default": "./dist/utils.js"
+      "default": {
+        "types": "./dist/utils.d.ts",
+        "default": "./dist/utils.js"
+      }
     },
     "./problems": {
       "development": "./src/problems.ts",
-      "default": "./dist/problems.js"
+      "default": {
+        "types": "./dist/problems.d.ts",
+        "default": "./dist/problems.js"
+      }
     },
     "./versions": {
       "node": "./dist/versions.js"


### PR DESCRIPTION
Addresses #175. Did a sanity check using the CLI and the exports are still happy:
<img width="1634" alt="image" src="https://github.com/arethetypeswrong/arethetypeswrong.github.io/assets/1824291/5f5767ee-8acd-4221-84e7-bb05ff012f4e">
