### PR TITLE
Fix warning message json-format suggestion to proper syntax

### DIFF
--- a/.changeset/kind-ducks-compare.md
+++ b/.changeset/kind-ducks-compare.md
@@ -1,0 +1,5 @@
+---
+"@arethetypeswrong/cli": patch
+---
+
+Fix warning message json-format suggestion to use proper syntax

--- a/packages/cli/src/render/typed.ts
+++ b/packages/cli/src/render/typed.ts
@@ -49,7 +49,7 @@ export async function typed(
     const summaryTexts = Object.keys(grouped).map((kind) => {
       const info = problemKindInfo[kind as core.ProblemKind];
       const description = marked(
-        `${info.description}${info.details ? ` Use \`--json\` to see ${info.details}.` : ""} ${info.docsUrl}`,
+        `${info.description}${info.details ? ` Use \`-f json\` to see ${info.details}.` : ""} ${info.docsUrl}`,
       );
       return `${emoji ? `${info.emoji} ` : ""}${description}`;
     });


### PR DESCRIPTION
The warning message appears for example as "Use --json to see the list of exports TypeScript can see but Node.js cannot." However, passing `--json` leads to an error: `error: unknown option '--json'`

Per `--help` documentation, the correct syntax is `-f json` or `--format json`, which I confirmed worked for me.

---

Side note: thank you for this super helpful package! I've been recently trying to deal with module resolution hell in a package of mine (still have yet to get things playing nicely with both CJS and ESM, now due to NextJS issues 😅), and this has been a handy resource 🙏 