### PR TITLE
test: support testing on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,7 +40,7 @@
     "tsc": "tsc -b",
     "local:install": "npm install -g .",
     "local:uninstall": "npm uninstall -g @arethetypeswrong/cli",
-    "test": "tsc -b test && node --test 'test/dist/**/*.test.js'",
+    "test": "tsc -b test && node --test \"test/dist/**/*.test.js\"",
     "prepack": "pnpm tsc"
   },
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "tsc": "tsc",
-    "test": "tsc -b test && node --test 'test/dist/**/*.test.js'",
+    "test": "tsc -b test && node --test \"test/dist/**/*.test.js\"",
     "snapshot": "node scripts/createSnapshotFixture.js",
     "prepack": "pnpm tsc"
   },

--- a/packages/core/test/snapshots.test.ts
+++ b/packages/core/test/snapshots.test.ts
@@ -58,22 +58,19 @@ describe("snapshots", async () => {
       }
 
       const snapshotURL = new URL(`../snapshots/${fixture}.json`, import.meta.url);
-      const expectedSnapshot = JSON.stringify(analysis, null, 2) + "\n";
+      const actualSnapshot = JSON.stringify(analysis, null, 2) + "\n";
 
       if (
-        await access(snapshotURL)
+        !updateSnapshots &&
+        (await access(snapshotURL)
           .then(() => true)
-          .catch(() => false)
+          .catch(() => false))
       ) {
         const snapshot = await readFile(snapshotURL, "utf8");
-        if (updateSnapshots) {
-          await writeFile(snapshotURL, expectedSnapshot);
-          snapshotsWritten.push(snapshotURL);
-        } else {
-          assert.strictEqual(snapshot, expectedSnapshot);
-        }
+        const expectedSnapshot = snapshot.replace(/\r\n/g, "\n");
+        assert.strictEqual(actualSnapshot, expectedSnapshot);
       } else {
-        await writeFile(snapshotURL, expectedSnapshot);
+        await writeFile(snapshotURL, actualSnapshot);
         snapshotsWritten.push(snapshotURL);
       }
     });

--- a/packages/core/test/utils.ts
+++ b/packages/core/test/utils.ts
@@ -14,7 +14,7 @@ export function createTestPackage(
           assert(name.startsWith(`/node_modules/${packageName}/`));
           return [name, content];
         }
-        return [path.join(`/node_modules/${packageName}`, name), content];
+        return [path.posix.join(`/node_modules/${packageName}`, name), content];
       }),
     ),
     packageName,


### PR DESCRIPTION
- package.json_s: use compatible quoting
- use posix paths in createTestPackage
- convert `\r\n` to `\n` before comparing strings
  - correct naming of snapshot strings; deduplicate write logic
- resolve file relative paths with `fileURLToPath`
- add Windows to CI test matrix