### PR TITLE
Fix typo in MissingExportEquals message

### DIFF
--- a/.changeset/eight-turkeys-crash.md
+++ b/.changeset/eight-turkeys-crash.md
@@ -1,0 +1,6 @@
+---
+"@arethetypeswrong/core": patch
+"@arethetypeswrong/cli": patch
+---
+
+Fix typo in MissingExportEquals message

--- a/docs/problems/MissingExportEquals.md
+++ b/docs/problems/MissingExportEquals.md
@@ -1,6 +1,6 @@
 # ❓ Missing `export =`
 
-The JavaScript appears to set both `module.exports` and `module.exports.default` for improved compatibility, but the types only reflect the latter (by using `export default`). This will cause TypeScript under the `node16` module mode to think an extra `.default` property access is required, which will work at runtime but is not necessary. These types `export =` an object with a `default` property instead of using `export default`.
+The JavaScript appears to set both `module.exports` and `module.exports.default` for improved compatibility, but the types only reflect the latter (by using `export default`). This will cause TypeScript under the `node16` module mode to think an extra `.default` property access is required, which will work at runtime but is not necessary. These types should `export =` an object with a `default` property instead of using `export default`.
 
 ## Explanation
 

--- a/packages/cli/test/snapshots/@vitejs__plugin-react@3.1.0.tgz.md
+++ b/packages/cli/test/snapshots/@vitejs__plugin-react@3.1.0.tgz.md
@@ -6,7 +6,7 @@ $ attw @vitejs__plugin-react@3.1.0.tgz -f table-flipped
 
 @vitejs/plugin-react v3.1.0
 
-❓ The JavaScript appears to set both module.exports and module.exports.default for improved compatibility, but the types only reflect the latter (by using export default). This will cause TypeScript under the node16 module mode to think an extra .default property access is required, which will work at runtime but is not necessary. These types export = an object with a default property instead of using export default. https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/MissingExportEquals.md
+❓ The JavaScript appears to set both module.exports and module.exports.default for improved compatibility, but the types only reflect the latter (by using export default). This will cause TypeScript under the node16 module mode to think an extra .default property access is required, which will work at runtime but is not necessary. These types should export = an object with a default property instead of using export default. https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/MissingExportEquals.md
 
 🎭 Import resolved to a CommonJS type declaration file, but an ESM JavaScript file. https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseCJS.md
 

--- a/packages/cli/test/snapshots/ajv@8.12.0.tgz.md
+++ b/packages/cli/test/snapshots/ajv@8.12.0.tgz.md
@@ -11,7 +11,7 @@ Build tools:
 - rollup@^2.44.0
 - @rollup/plugin-typescript@^10.0.1
 
-❓ The JavaScript appears to set both module.exports and module.exports.default for improved compatibility, but the types only reflect the latter (by using export default). This will cause TypeScript under the node16 module mode to think an extra .default property access is required, which will work at runtime but is not necessary. These types export = an object with a default property instead of using export default. https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/MissingExportEquals.md
+❓ The JavaScript appears to set both module.exports and module.exports.default for improved compatibility, but the types only reflect the latter (by using export default). This will cause TypeScript under the node16 module mode to think an extra .default property access is required, which will work at runtime but is not necessary. These types should export = an object with a default property instead of using export default. https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/MissingExportEquals.md
 
 
 ┌───────┬───────────────────────┬───────────────────────┬───────────────────────┬───────────────────────┐

--- a/packages/cli/test/snapshots/postcss@8.4.21.tgz.md
+++ b/packages/cli/test/snapshots/postcss@8.4.21.tgz.md
@@ -6,7 +6,7 @@ $ attw postcss@8.4.21.tgz -f table-flipped
 
 postcss v8.4.21
 
-❓ The JavaScript appears to set both module.exports and module.exports.default for improved compatibility, but the types only reflect the latter (by using export default). This will cause TypeScript under the node16 module mode to think an extra .default property access is required, which will work at runtime but is not necessary. These types export = an object with a default property instead of using export default. https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/MissingExportEquals.md
+❓ The JavaScript appears to set both module.exports and module.exports.default for improved compatibility, but the types only reflect the latter (by using export default). This will cause TypeScript under the node16 module mode to think an extra .default property access is required, which will work at runtime but is not necessary. These types should export = an object with a default property instead of using export default. https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/MissingExportEquals.md
 
 🐛 Import resolved to types through a conditional package.json export, but only after failing to resolve through an earlier condition. This behavior is a TypeScript bug (https://github.com/microsoft/TypeScript/issues/50762). It may misrepresent the runtime behavior of this import and should not be relied upon. https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FallbackCondition.md
 

--- a/packages/core/src/problems.ts
+++ b/packages/core/src/problems.ts
@@ -90,7 +90,7 @@ export const problemKindInfo: Record<ProblemKind, ProblemKindInfo> = {
     title: "Types are missing an `export =`",
     shortDescription: "Missing `export =`",
     description:
-      "The JavaScript appears to set both `module.exports` and `module.exports.default` for improved compatibility, but the types only reflect the latter (by using `export default`). This will cause TypeScript under the `node16` module mode to think an extra `.default` property access is required, which will work at runtime but is not necessary. These types `export =` an object with a `default` property instead of using `export default`.",
+      "The JavaScript appears to set both `module.exports` and `module.exports.default` for improved compatibility, but the types only reflect the latter (by using `export default`). This will cause TypeScript under the `node16` module mode to think an extra `.default` property access is required, which will work at runtime but is not necessary. These types should `export =` an object with a `default` property instead of using `export default`.",
     docsUrl:
       "https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/MissingExportEquals.md",
   },


### PR DESCRIPTION
I think the word "should" is missing here.

```diff
- These types export = an object with a default property instead of using export default.
+ These types should export = an object with a default property instead of using export default.
```