### PR TITLE
Docs: NoResolution: Hint at how to ignore the issue

### DIFF
--- a/docs/problems/NoResolution.md
+++ b/docs/problems/NoResolution.md
@@ -37,3 +37,7 @@ When this problem occurs for the `node10` resolution option but not any others, 
 In this example, an import of `"pkg/subpath"` can be used in Node 12+ and modern bundlers, but would fail to resolve in Node 10. Accordingly, TypeScript’s `--moduleResolution node10` (also confusingly known as `node`, because history) does not resolve `"exports"` either.
 
 While few libraries care about supporting a long-past EOL version of Node, maintainers of very popular libraries should be aware that many TypeScript users are still using `--moduleResolution node`. If they aren’t literally using Node 10, they really should move away from it, but sometimes migrating can be difficult because it introduces new errors caused by _incorrect dependency typings_—the problem this tool was made to diagnose. Popular libraries often choose to adopt a strategy that allows `--moduleResolution node10` to work even without `"exports"` support. https://github.com/andrewbranch/example-subpath-exports-ts-compat demonstrates several such strategies.
+
+## Ignore issue
+
+You can use the `profile` `node16` to ignore this issue. It will be reported as `node10: (ignored) 💀 Resolution failed` with a red export path but it the check will not exit with an error anymore. [Learn more in the CLI Readme](https://github.com/jason-ha/arethetypeswrong/blob/8f9afe019ade7d25ef81da7c50f819328edcecae/packages/cli/README.md#profiles).

--- a/docs/problems/NoResolution.md
+++ b/docs/problems/NoResolution.md
@@ -40,4 +40,4 @@ While few libraries care about supporting a long-past EOL version of Node, maint
 
 ## Ignore issue
 
-You can use the `profile` `node16` to ignore this issue. It will be reported as `node10: (ignored) 💀 Resolution failed` with a red export path but it the check will not exit with an error anymore. [Learn more in the CLI Readme](https://github.com/jason-ha/arethetypeswrong/blob/8f9afe019ade7d25ef81da7c50f819328edcecae/packages/cli/README.md#profiles).
+You can use the `profile` `node16` to ignore this issue. It will be reported as `node10: (ignored) 💀 Resolution failed` with a red export path but it the check will not exit with an error anymore. [Learn more in the CLI Readme](https://github.com/arethetypeswrong/arethetypeswrong.github.io/tree/main/packages/cli#profiles).

--- a/docs/problems/NoResolution.md
+++ b/docs/problems/NoResolution.md
@@ -38,6 +38,5 @@ In this example, an import of `"pkg/subpath"` can be used in Node 12+ and modern
 
 While few libraries care about supporting a long-past EOL version of Node, maintainers of very popular libraries should be aware that many TypeScript users are still using `--moduleResolution node`. If they aren’t literally using Node 10, they really should move away from it, but sometimes migrating can be difficult because it introduces new errors caused by _incorrect dependency typings_—the problem this tool was made to diagnose. Popular libraries often choose to adopt a strategy that allows `--moduleResolution node10` to work even without `"exports"` support. https://github.com/andrewbranch/example-subpath-exports-ts-compat demonstrates several such strategies.
 
-## Ignore issue
 
-You can use the `profile` `node16` to ignore this issue. It will be reported as `node10: (ignored) 💀 Resolution failed` with a red export path but it the check will not exit with an error anymore. [Learn more in the CLI Readme](https://github.com/arethetypeswrong/arethetypeswrong.github.io/tree/main/packages/cli#profiles).
+> You can use the [`--profile node16` option on the CLI](https://github.com/arethetypeswrong/arethetypeswrong.github.io/tree/main/packages/cli#profiles) to ignore issues that only affect `--moduleResolution node10`.


### PR DESCRIPTION
I am running in to https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/NoResolution.md and the current docs don't help much in cases when I don't care about the issue.

I think the new feature introduced in https://github.com/arethetypeswrong/arethetypeswrong.github.io/issues/112 should be documented on this error page so users have a quick way find the docs on how to skip the error.


