### PR TITLE
fix: move pnpm patchedDependencies into pnpm-workspace.yaml

### DIFF
--- a/.changeset/tricky-cats-live.md
+++ b/.changeset/tricky-cats-live.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+fix: move pnpm patchedDependencies into pnpm-workspace.yaml

--- a/package.json
+++ b/package.json
@@ -22,11 +22,6 @@
   },
   "engines": {
     "node": ">=22",
-    "pnpm": ">=9"
-  },
-  "pnpm": {
-    "patchedDependencies": {
-      "cjs-module-lexer@1.4.0": "patches/cjs-module-lexer@1.4.0.patch"
-    }
+    "pnpm": ">=10"
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
 packages:
 - 'packages/*'
+
+patchedDependencies:
+  cjs-module-lexer@1.4.0: patches/cjs-module-lexer@1.4.0.patch


### PR DESCRIPTION
## TL;DR

The `cjs-module-lexer@1.4.0` patch was registered in the root `package.json`'s
`pnpm` field. pnpm 10+ no longer reads project settings from there, and pnpm 11
ignores that field entirely — emitting only a single non-fatal `WARN`. The
result: **`pnpm install` silently skips the patch**, and `attw` then runs
against an *unpatched* `cjs-module-lexer`, the very library its CJS analysis is
built on. This PR moves `patchedDependencies` to `pnpm-workspace.yaml`, where
current pnpm reads it, and corrects the declared `pnpm` engine to match.

## Background — how pnpm patch configuration worked

`cjs-module-lexer` is patched in this repo via
`patches/cjs-module-lexer@1.4.0.patch`. For `pnpm install` to apply that patch,
pnpm needs a `patchedDependencies` map naming the package + version to patch and
the patch file to use.

Through pnpm 7, 8, and 9, the canonical home for that map — and for pnpm's other
project-level settings (`overrides`, `peerDependencyRules`,
`onlyBuiltDependencies`, and so on) — was the **`pnpm` key in the root
`package.json`**:

```jsonc
// package.json
"pnpm": {
  "patchedDependencies": {
    "cjs-module-lexer@1.4.0": "patches/cjs-module-lexer@1.4.0.patch"
  }
}
```

In that era, `pnpm-workspace.yaml` held only the workspace package globs
(`packages:`).

## What changed in pnpm 10 / 11

pnpm 10 began consolidating project settings into `pnpm-workspace.yaml`. The
keys that used to live under `package.json`'s `pnpm` object — including
`patchedDependencies` — became top-level keys in `pnpm-workspace.yaml`:

```yaml
# pnpm-workspace.yaml
patchedDependencies:
  cjs-module-lexer@1.4.0: patches/cjs-module-lexer@1.4.0.patch
```

By pnpm 11, the `package.json` `pnpm` field is **no longer read at all**. pnpm 11
surfaces this only as one non-fatal warning during install:

```
WARN  The "pnpm" field in package.json is no longer read by pnpm.
      The following keys were ignored: "pnpm.patchedDependencies"
```

`pnpm install` then exits 0. Nothing fails.

## The problem

This repo still declared `patchedDependencies` in `package.json`. Combined with
the change above, that produces a **silent correctness failure**:

1. `pnpm install` on pnpm 11 prints the one-line `WARN` and ignores
   `pnpm.patchedDependencies`.
2. `cjs-module-lexer@1.4.0` is therefore installed **vanilla — the patch is
   never applied.**
3. `cjs-module-lexer` is not incidental here. It is the library
   `@arethetypeswrong/core` uses to statically determine a CommonJS module's
   named exports and re-exports. It is load-bearing for every CJS analysis
   `attw` performs.
4. `patches/cjs-module-lexer@1.4.0.patch` rewrites `cjs-module-lexer`'s
   `dist/lexer.js`. Whatever that patch corrects or adjusts is, when the patch
   is skipped, silently reverted — `attw` analyzes against stock
   `cjs-module-lexer`.

The dangerous part is the *silence*. There is:

- no install failure (exit 0);
- no test failure (the suite does not assert the patch was applied);
- no runtime error (`attw` runs perfectly well against an unpatched
  `cjs-module-lexer`);

— only one easily-missed `WARN` line in `pnpm install` output. A contributor on
pnpm 10+ ends up with a subtly-wrong `attw` and no signal that anything is off.

Compounding it: `engines.pnpm` declared `">=9"` — advertising support for
exactly the pnpm versions across which this silently breaks. The stated
constraint actively misled.

### How this surfaced

This was found while using a local build of this fork to check the types of an
unrelated package (`StoneCypher/better_git_changelog#20`). The `pnpm install`
step printed the `WARN`; tracing it back showed the patch had never been applied
in that build.

## The fix

1. **Move `patchedDependencies` from `package.json` into
   `pnpm-workspace.yaml`** — the location current pnpm reads.
2. **Remove the now-dead `pnpm` field from `package.json`** — leaving it would
   only re-trigger the `WARN` on every pnpm 11 install.
3. **Bump `engines.pnpm` from `">=9"` to `">=10"`.** This one is deliberate and
   worth a maintainer's eye: the `pnpm-workspace.yaml` location is read by
   pnpm 10+, not by pnpm 9. Rather than duplicate the config in both files
   (which would still `WARN` on pnpm 11), this PR narrows the supported range so
   the declared engine matches the actual requirement. If pnpm 9 support must be
   kept, the alternative is to duplicate the `patchedDependencies` map in both
   locations and accept the pnpm-11 warning.

## Verification

With this change, `pnpm install` (pnpm 11.1.3 via corepack):

- emits no "ignored field" warning;
- applies the patch — pnpm creates the patched store variant
  `cjs-module-lexer@1.4.0_patc_<hash>`, and
  `packages/core/node_modules/cjs-module-lexer` symlinks to it (verified).

Re-running `attw --pack` against the test package above with the patched lexer
in place produced the same verdict as before — for that particular (plain
CommonJS) package the patched and unpatched lexer happened to agree — but the
toolchain is now correct by construction rather than by luck.

> Note: pnpm 11 separately reports `esbuild`'s install script as un-approved.
> That is pre-existing, unrelated to this change, and handled independently via
> `pnpm approve-builds`.
