### PR TITLE
fix(core): concatenate multi-chunk gunzip output in extractTarball

### DIFF
--- a/.changeset/fix-multi-chunk-tarball.md
+++ b/.changeset/fix-multi-chunk-tarball.md
@@ -1,0 +1,15 @@
+---
+"@arethetypeswrong/core": patch
+---
+
+Fix crash on packages whose tarball gunzips into multiple chunks
+
+`extractTarball` assigned `unzipped = chunk` in the `Gunzip` streaming callback,
+which keeps only the last emitted chunk. fflate emits multiple chunks for larger
+tarballs, so for any package big enough to decompress into more than one chunk
+the callback discarded everything but the final (often empty) chunk. `untar`
+then returned zero files and the next line crashed with
+`Cannot read properties of undefined (reading 'filename')` on `data[0]`.
+
+The chunks are now concatenated before being passed to `untar`, so larger
+packages are handled correctly.

--- a/packages/core/src/createPackage.ts
+++ b/packages/core/src/createPackage.ts
@@ -294,10 +294,23 @@ export function createPackageFromTarballData(tarball: Uint8Array): Package {
 }
 
 function extractTarball(tarball: Uint8Array) {
-  // Use streaming API to work around https://github.com/101arrowz/fflate/issues/207
-  let unzipped: Uint8Array;
-  new Gunzip((chunk) => (unzipped = chunk)).push(tarball, /*final*/ true);
-  const data = untar(unzipped!);
+  // Use streaming API to work around https://github.com/101arrowz/fflate/issues/207.
+  // The streaming callback fires once per output chunk, and fflate emits multiple
+  // chunks for larger tarballs — so the chunks must be concatenated. Assigning
+  // `unzipped = chunk` kept only the last (often empty) chunk, which made `untar`
+  // return zero files and crashed below on `data[0].filename` for any package big
+  // enough to gunzip into more than one chunk.
+  const chunks: Uint8Array[] = [];
+  new Gunzip((chunk) => chunks.push(chunk)).push(tarball, /*final*/ true);
+  let totalLength = 0;
+  for (const chunk of chunks) totalLength += chunk.length;
+  const unzipped = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    unzipped.set(chunk, offset);
+    offset += chunk.length;
+  }
+  const data = untar(unzipped);
   const prefix = data[0].filename.substring(0, data[0].filename.indexOf("/") + 1);
   const packageJsonText = data.find((f) => f.filename === `${prefix}package.json`)?.fileData;
   const packageJson = JSON.parse(new TextDecoder().decode(packageJsonText));


### PR DESCRIPTION
## Problem

`extractTarball` (`packages/core/src/createPackage.ts`) crashes with `Cannot read properties of undefined (reading 'filename')` for any package whose tarball gunzips into more than one chunk.

```ts
let unzipped: Uint8Array;
new Gunzip((chunk) => (unzipped = chunk)).push(tarball, /*final*/ true);
const data = untar(unzipped!);
const prefix = data[0].filename.substring(...);  // 💥 data[0] is undefined
```

fflate's `Gunzip` streaming callback fires **once per output chunk**, and it emits multiple chunks for larger tarballs. Assigning `unzipped = chunk` keeps only the **last** chunk (frequently the empty final flush), so `untar` receives a truncated buffer, returns **zero files**, and the next line dereferences `data[0]`.

This is size-dependent: small packages decompress in a single chunk and work; larger ones (reproduced with a ~72 KB / 92-file package that gunzips into 3 chunks) crash. `attw --pack .` / tarball checks fail in CI for affected packages.

## Fix

Accumulate the streamed chunks and concatenate them before `untar`:

```ts
const chunks: Uint8Array[] = [];
new Gunzip((chunk) => chunks.push(chunk)).push(tarball, /*final*/ true);
let totalLength = 0;
for (const chunk of chunks) totalLength += chunk.length;
const unzipped = new Uint8Array(totalLength);
let offset = 0;
for (const chunk of chunks) { unzipped.set(chunk, offset); offset += chunk.length; }
const data = untar(unzipped);
```

## Verification

- `@arethetypeswrong/core` test suite passes (55/55), including large multi-chunk fixtures (e.g. `next@14.0.3`).
- Built the CLI with this fix and confirmed it now produces a normal report (no crash) on the previously-crashing package.

Changeset included (patch).