### PR TITLE
Use tsgo for local build/check, update @types/node

### DIFF
--- a/.changeset/fair-paws-cover.md
+++ b/.changeset/fair-paws-cover.md
@@ -1,0 +1,6 @@
+---
+"@arethetypeswrong/core": patch
+"@arethetypeswrong/cli": patch
+---
+
+Update @types/node, use @typescript/native-preview for local build/check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version: 22
       - run: pnpm install --frozen-lockfile
-      - run: pnpm tsc
+      - run: pnpm tsgo
       - run: pnpm build
       - run: pnpm test
       - run: pnpm check-dts

--- a/package.json
+++ b/package.json
@@ -7,18 +7,18 @@
   },
   "license": "MIT",
   "scripts": {
-    "tsc": "tsc -b",
-    "build": "pnpm tsc && pnpm -r build",
+    "tsgo": "tsgo -b",
+    "build": "pnpm tsgo && pnpm -r build",
     "format": "prettier --write \"**/*.{ts,json,css}\"",
     "test": "pnpm -r test",
-    "check-dts": "tsc -p tsconfig.check-dts.json",
+    "check-dts": "tsgo -p tsconfig.check-dts.json",
     "start": "pnpm --filter @arethetypeswrong/web start",
     "version": "changeset version && pnpm install --lockfile-only"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.8",
-    "prettier": "^3.0.3",
-    "typescript": "5.6.1-rc"
+    "@typescript/native-preview": "7.0.0-dev.20260527.2",
+    "prettier": "^3.0.3"
   },
   "engines": {
     "node": ">=22",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,17 +37,17 @@
     "access": "public"
   },
   "scripts": {
-    "tsc": "tsc -b",
+    "tsgo": "tsgo -b",
     "local:install": "npm install -g .",
     "local:uninstall": "npm uninstall -g @arethetypeswrong/cli",
-    "test": "tsc -b test && node --test \"test/dist/**/*.test.js\"",
-    "prepack": "pnpm tsc"
+    "test": "tsgo -b test && node --test \"test/dist/**/*.test.js\"",
+    "prepack": "pnpm tsgo"
   },
   "type": "module",
   "devDependencies": {
     "@types/marked": "^5.0.0",
     "@types/marked-terminal": "^3.1.3",
-    "@types/node": "^22.5.0",
+    "@types/node": "^25.9.1",
     "@types/semver": "^7.5.3",
     "ts-expose-internals": "5.6.1-rc"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,10 +18,10 @@
     "access": "public"
   },
   "scripts": {
-    "tsc": "tsc",
-    "test": "tsc -b test && node --test \"test/dist/**/*.test.js\"",
+    "tsgo": "tsgo",
+    "test": "tsgo -b test && node --test \"test/dist/**/*.test.js\"",
     "snapshot": "node scripts/createSnapshotFixture.js",
-    "prepack": "pnpm tsc"
+    "prepack": "pnpm tsgo"
   },
   "type": "module",
   "imports": {
@@ -60,7 +60,7 @@
     "validate-npm-package-name": "^5.0.0"
   },
   "devDependencies": {
-    "@types/node": "^22.5.0",
+    "@types/node": "^25.9.1",
     "@types/semver": "^7.5.0",
     "@types/validate-npm-package-name": "^4.0.0",
     "ts-expose-internals": "5.6.1-rc"

--- a/packages/core/src/createPackage.ts
+++ b/packages/core/src/createPackage.ts
@@ -300,7 +300,7 @@ function extractTarball(tarball: Uint8Array) {
     new Gunzip((chunk) => chunks.push(chunk)).push(tarball, /*final*/ true);
   } catch (err: any) {
     // this happens for zero-padded tarballs; can safely ignore
-    if (err.code != FlateErrorCode.InvalidHeader) {
+    if (err.code !== FlateErrorCode.InvalidHeader) {
       throw err;
     }
   }
@@ -310,7 +310,7 @@ function extractTarball(tarball: Uint8Array) {
     unzipped.set(chunk, offset);
     offset += chunk.length;
   }
-  const data = untar(unzipped);
+  const data = untar(unzipped.buffer);
   const prefix = data[0].filename.substring(0, data[0].filename.indexOf("/") + 1);
   const packageJsonText = data.find((f) => f.filename === `${prefix}package.json`)?.fileData;
   const packageJson = JSON.parse(new TextDecoder().decode(packageJsonText));

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -28,10 +28,10 @@
     }
   },
   "scripts": {
-    "tsc": "tsc -b",
-    "build:scripts": "tsc -b scripts",
+    "tsgo": "tsgo -b",
+    "build:scripts": "tsgo -b scripts",
     "generate": "pnpm build:scripts && tsx scripts/generateFull.ts",
-    "prepublishOnly": "pnpm tsc && pnpm generate"
+    "prepublishOnly": "pnpm tsgo && pnpm generate"
   },
   "dependencies": {
     "@arethetypeswrong/core": "workspace:*"
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@azure/storage-blob": "^12.14.0",
     "@types/cli-progress": "^3.11.0",
-    "@types/node": "^22.5.0",
+    "@types/node": "^25.9.1",
     "@types/pacote": "^11.1.5",
     "@types/semver": "^7.5.0",
     "cli-progress": "^3.12.0",

--- a/packages/history/src/utils.js
+++ b/packages/history/src/utils.js
@@ -45,7 +45,7 @@ export function getVersionsAtDateWithTypes(date, versionsByDate, data) {
 /**
  * @typedef {{
  *   packageName: string;
- *   fixedByVersion: string;
+ *   fixedByVersion: string | undefined;
  *   fixedByDate: string;
  * }} FixedPackage
  */

--- a/packages/history/tsconfig.json
+++ b/packages/history/tsconfig.json
@@ -5,6 +5,7 @@
     "checkJs": true,
     "declaration": true,
     "emitDeclarationOnly": true,
+    "rootDir": "src",
     "outDir": "lib",
     "types": ["node"]
   },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "tsc": "tsc -b",
+    "tsgo": "tsgo -b",
     "build": "vite build",
     "start": "vite dev"
   },
@@ -16,7 +16,8 @@
     "@arethetypeswrong/core": "workspace:*",
     "immer": "^9.0.21",
     "marked": "^5.1.0",
-    "nprogress": "^0.2.0"
+    "nprogress": "^0.2.0",
+    "typescript": "5.6.1-rc"
   },
   "devDependencies": {
     "@types/marked": "^5.0.0",

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -6,7 +6,8 @@
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "emitDeclarationOnly": true,
-    "outDir": "lib"
+    "outDir": "lib",
+    "noUncheckedSideEffectImports": false,
   },
   "include": ["src", "package.json"],
   "references": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,12 @@ importers:
       '@changesets/cli':
         specifier: ^2.27.8
         version: 2.27.8
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260527.2
+        version: 7.0.0-dev.20260527.2
       prettier:
         specifier: ^3.0.3
         version: 3.0.3
-      typescript:
-        specifier: 5.6.1-rc
-        version: 5.6.1-rc
 
   packages/cli:
     dependencies:
@@ -52,8 +52,8 @@ importers:
         specifier: ^3.1.3
         version: 3.1.6
       '@types/node':
-        specifier: ^22.5.0
-        version: 22.5.0
+        specifier: ^25.9.1
+        version: 25.9.1
       '@types/semver':
         specifier: ^7.5.3
         version: 7.5.3
@@ -89,8 +89,8 @@ importers:
         version: 5.0.0
     devDependencies:
       '@types/node':
-        specifier: ^22.5.0
-        version: 22.5.0
+        specifier: ^25.9.1
+        version: 25.9.1
       '@types/semver':
         specifier: ^7.5.0
         version: 7.5.3
@@ -114,8 +114,8 @@ importers:
         specifier: ^3.11.0
         version: 3.11.3
       '@types/node':
-        specifier: ^22.5.0
-        version: 22.5.0
+        specifier: ^25.9.1
+        version: 25.9.1
       '@types/pacote':
         specifier: ^11.1.5
         version: 11.1.6
@@ -164,6 +164,9 @@ importers:
       nprogress:
         specifier: ^0.2.0
         version: 0.2.0
+      typescript:
+        specifier: 5.6.1-rc
+        version: 5.6.1-rc
     devDependencies:
       '@types/marked':
         specifier: ^5.0.0
@@ -176,7 +179,7 @@ importers:
         version: 0.19.4
       vite:
         specifier: ^4.4.11
-        version: 4.4.11(@types/node@22.5.0)
+        version: 4.4.11(@types/node@25.9.1)
 
 packages:
 
@@ -658,8 +661,8 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@22.5.0':
-    resolution: {integrity: sha512-DkFrJOe+rfdHTqqMg0bSNlGlQ85hSoh2TPzZyhHsXnMtligRWpxUySiyw8FY14ITt24HVCiQPWxS3KO/QlGmWg==}
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
   '@types/npm-package-arg@6.1.2':
     resolution: {integrity: sha512-K7TdZq7dTZKKgxaFGLR6VPAeNMDM7GwTELlVNyzQ0KKc6Du3+SYYRXFNEDrsCptpEpMjMNKVlb/5/ZNS/MeHjw==}
@@ -687,6 +690,53 @@ packages:
 
   '@types/validate-npm-package-name@4.0.0':
     resolution: {integrity: sha512-RpO62vB2lkjEkyLbwTheA2+uwYmtVMWTr/kWRI++UAgVdZqNqdAuIQl/SxBCGeMKfdjWaXPbyhZbiCc4PAj+KA==}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260527.2':
+    resolution: {integrity: sha512-3LqSu4DlxkEfeC/Z/29QMCJn5jjkDtXI7LYuxfmjdmAatS6umDKqm8J17fnP/7fyrZUMBTIYRwSDpChGV3G1ew==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260527.2':
+    resolution: {integrity: sha512-H4+sxE9qaBbLF83wMdWE0FsgfK0Pom+/O+/oxqyGzhVkDJlNt3vfpgQZMit48/Gm44AacGfBggJ9Dhbi3aeSFw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260527.2':
+    resolution: {integrity: sha512-BGUDMjC2Z3TTdZRkGGwhBLelkP5UYgO2rbep8aF4dS3fu7T5lFPPrnfS6EgqJgie+cF5Fsev7xEq8wWyBDM+lg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260527.2':
+    resolution: {integrity: sha512-6I9Cv9ozwfS9zB9vRQDPIYseLX3artEO9jl3yVgLj4ishwlSF4cWAbIsjl5IztPaEgHv8coej/6tX1D0uaBzXg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260527.2':
+    resolution: {integrity: sha512-vpazOu+ozlxBo8U57YJMzsOPuxAV8H7fu36KJ8ea8At/D8pdGmOAy5TuB+9OBQV9JDe0OXJMy2kmbhOpmkTAmA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260527.2':
+    resolution: {integrity: sha512-DBFnFE3V6AITkPO1K1VxXf3yEZKjU2FwtXlNwRqhzDu0rrL2SsJHOSrBDX+OacTxQFzZMxFcpiuhV8jHZALPEg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260527.2':
+    resolution: {integrity: sha512-1tBlErMvQgcMqqYwsx4tytupcjCJcOUXD3vBn1Wb/kAvus1FzWQAFE0fcKBvLfcqLQfTiiEwKKEtbLjGmakqqg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260527.2':
+    resolution: {integrity: sha512-piqkDwikVeizCFqA1lcwI5F4wOAtBdxuliWe77ApBNRyBPPvfCJB+u/HYi9/8t5nd0sWvFs6/qt/AzJ1CCoykQ==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
 
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -1747,8 +1797,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@6.19.8:
-    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   unicode-emoji-modifier-base@1.0.0:
     resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
@@ -2344,7 +2394,7 @@ snapshots:
 
   '@types/cli-progress@3.11.3':
     dependencies:
-      '@types/node': 22.5.0
+      '@types/node': 25.9.1
 
   '@types/marked-terminal@3.1.6':
     dependencies:
@@ -2355,20 +2405,20 @@ snapshots:
 
   '@types/node-fetch@2.6.6':
     dependencies:
-      '@types/node': 22.5.0
+      '@types/node': 25.9.1
       form-data: 4.0.0
 
   '@types/node@12.20.55': {}
 
-  '@types/node@22.5.0':
+  '@types/node@25.9.1':
     dependencies:
-      undici-types: 6.19.8
+      undici-types: 7.24.6
 
   '@types/npm-package-arg@6.1.2': {}
 
   '@types/npm-registry-fetch@8.0.5':
     dependencies:
-      '@types/node': 22.5.0
+      '@types/node': 25.9.1
       '@types/node-fetch': 2.6.6
       '@types/npm-package-arg': 6.1.2
       '@types/npmlog': 4.1.4
@@ -2380,7 +2430,7 @@ snapshots:
 
   '@types/pacote@11.1.6':
     dependencies:
-      '@types/node': 22.5.0
+      '@types/node': 25.9.1
       '@types/npm-registry-fetch': 8.0.5
       '@types/npmlog': 4.1.4
       '@types/ssri': 7.1.2
@@ -2389,13 +2439,44 @@ snapshots:
 
   '@types/ssri@7.1.2':
     dependencies:
-      '@types/node': 22.5.0
+      '@types/node': 25.9.1
 
   '@types/tunnel@0.0.3':
     dependencies:
-      '@types/node': 22.5.0
+      '@types/node': 25.9.1
 
   '@types/validate-npm-package-name@4.0.0': {}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260527.2':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260527.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260527.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260527.2':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260527.2':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260527.2':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260527.2':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260527.2':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260527.2
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260527.2
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260527.2
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260527.2
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260527.2
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260527.2
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260527.2
 
   abbrev@1.1.1: {}
 
@@ -3484,7 +3565,7 @@ snapshots:
 
   typescript@5.6.1-rc: {}
 
-  undici-types@6.19.8: {}
+  undici-types@7.24.6: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 
@@ -3511,13 +3592,13 @@ snapshots:
     dependencies:
       builtins: 5.0.1
 
-  vite@4.4.11(@types/node@22.5.0):
+  vite@4.4.11(@types/node@25.9.1):
     dependencies:
       esbuild: 0.18.20
       postcss: 8.4.31
       rollup: 3.29.4
     optionalDependencies:
-      '@types/node': 22.5.0
+      '@types/node': 25.9.1
       fsevents: 2.3.3
 
   webidl-conversions@3.0.1: {}


### PR DESCRIPTION
fflate 0.8.3 required a newer TypeScript version to check locally, so this PR updates the codebase to type check with @typescript/native-preview, while not changing the runtime TypeScript dependency version.