### PR TITLE
fix: add core package metadata

### DIFF
--- a/.changeset/bright-ravens-help.md
+++ b/.changeset/bright-ravens-help.md
@@ -1,0 +1,5 @@
+---
+"@arethetypeswrong/core": patch
+---
+
+Add bugs and homepage metadata to the published package manifest.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,6 +9,10 @@
     "url": "https://github.com/arethetypeswrong/arethetypeswrong.github.io.git",
     "directory": "packages/core"
   },
+  "bugs": {
+    "url": "https://github.com/arethetypeswrong/arethetypeswrong.github.io/issues"
+  },
+  "homepage": "https://arethetypeswrong.github.io",
   "files": [
     "LICENSE",
     "dist",


### PR DESCRIPTION
Adds the missing npm package metadata for `@arethetypeswrong/core`:

- `bugs.url` points to the repository issue tracker
- `homepage` points to the project website

Validation:
- `git diff --check`
- `pnpm --filter @arethetypeswrong/core pack --pack-destination /tmp/att-pack`
- verified the generated tarball package.json contains `repository`, `bugs`, and `homepage`
- `pnpm --filter @arethetypeswrong/core test` (55 tests passed)

Bounty: https://github.com/charles-openclaw/charles-microbounties/issues/745
