### PR TITLE
Add bugs URL to package.json

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,6 +19,9 @@
     "url": "https://github.com/arethetypeswrong/arethetypeswrong.github.io.git",
     "directory": "packages/cli"
   },
+  "bugs": {
+    "url": "https://github.com/arethetypeswrong/arethetypeswrong.github.io/issues"
+  },
   "files": [
     "LICENSE",
     "dist/**/*.js",


### PR DESCRIPTION
Add bugs URL metadata pointing npm users to the repository issue tracker. No runtime code changes.