### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@arethetypeswrong/cli",
   "version": "0.18.3",
+  "bugs": {
+    "url": "https://github.com/arethetypeswrong/arethetypeswrong.github.io/issues"
+  },
   "description": "A CLI tool for arethetypeswrong.github.io",
   "author": "Andrew Branch & ej-shafran",
   "contributors": [


### PR DESCRIPTION
Adds missing `bugs` metadata to `packages/cli/package.json`.