### PR TITLE
docs: add bugs metadata for @arethetypeswrong/cli

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,6 +14,9 @@
     }
   ],
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/arethetypeswrong/arethetypeswrong.github.io/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/arethetypeswrong/arethetypeswrong.github.io.git",


### PR DESCRIPTION
This PR adds the missing `bugs` metadata to the `@arethetypeswrong/cli` package, as requested in the microbounty issue #1327.

- Added `bugs` URL pointing to the repository issues.

Fixes #1327