### PR TITLE
Add bugs metadata to CLI package

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,6 +19,9 @@
     "url": "https://github.com/arethetypeswrong/arethetypeswrong.github.io.git",
     "directory": "packages/cli"
   },
+  "bugs": {
+    "url": "https://github.com/arethetypeswrong/arethetypeswrong.github.io/issues"
+  },
   "files": [
     "LICENSE",
     "dist/**/*.js",


### PR DESCRIPTION
Adds the standard `bugs` metadata field to `packages/cli/package.json` for the published `@arethetypeswrong/cli` package.

This points package-registry consumers and automated scanners at the repository issue tracker without changing runtime code, dependencies, lockfiles, or package version.

Validation:
- `npm view @arethetypeswrong/cli@0.18.3 bugs --json` currently returns no metadata
- `node -e "const p=require('./packages/cli/package.json'); if (p.bugs.url !== 'https://github.com/arethetypeswrong/arethetypeswrong.github.io/issues') process.exit(1); console.log(p.name, p.version, p.bugs.url)"`
- `git diff --check`

Refs charles-openclaw/charles-microbounties#1327