### PR TITLE
Skip null export targets during entrypoint discovery

### DIFF
--- a/.changeset/skip-null-export-targets.md
+++ b/.changeset/skip-null-export-targets.md
@@ -1,0 +1,5 @@
+---
+"@arethetypeswrong/core": patch
+---
+
+Skip package export subpaths with no real target when discovering entrypoints.

--- a/packages/core/src/internal/getEntrypointInfo.ts
+++ b/packages/core/src/internal/getEntrypointInfo.ts
@@ -34,7 +34,7 @@ function getEntrypoints(fs: Package, exportsObject: unknown, options: CheckPacka
     return proxies;
   }
   const detectedSubpaths = getSubpaths(exportsObject);
-  if (detectedSubpaths.length === 0) {
+  if (detectedSubpaths.length === 0 && hasExportTarget(exportsObject)) {
     detectedSubpaths.push(".");
   }
   const included = unique([
@@ -71,10 +71,23 @@ function getSubpaths(exportsObject: any): string[] {
     return [];
   }
   const keys = Object.keys(exportsObject);
-  if (keys[0].startsWith(".")) {
-    return keys;
+  if (keys[0]?.startsWith(".")) {
+    return keys.filter((key) => hasExportTarget(exportsObject[key]));
   }
   return keys.flatMap((key) => getSubpaths(exportsObject[key]));
+}
+
+function hasExportTarget(exportsObject: any): boolean {
+  if (exportsObject === null || exportsObject === undefined) {
+    return false;
+  }
+  if (typeof exportsObject !== "object") {
+    return true;
+  }
+  if (Array.isArray(exportsObject)) {
+    return exportsObject.some(hasExportTarget);
+  }
+  return Object.keys(exportsObject).some((key) => hasExportTarget(exportsObject[key]));
 }
 
 function getProxyDirectories(rootDir: string, fs: Package) {

--- a/packages/core/test/getEntrypointInfo.test.ts
+++ b/packages/core/test/getEntrypointInfo.test.ts
@@ -1,0 +1,37 @@
+import { checkPackage } from "@arethetypeswrong/core";
+import assert from "node:assert";
+import { describe, test } from "node:test";
+import { createTestPackage } from "./utils.js";
+
+describe("getEntrypointInfo", () => {
+  test("skips exports subpaths with null targets", async () => {
+    const result = await checkPackage(
+      createTestPackage({
+        "dist/browser.d.ts": "export {};",
+        "dist/browser.js": "export {};",
+        "index.d.ts": "export {};",
+        "package.json": JSON.stringify({
+          name: "test",
+          version: "1.0.0",
+          exports: {
+            "./features/*.js": "./src/features/*.js",
+            "./features/private-internal/*": null,
+            "./browser": {
+              node: null,
+              default: "./dist/browser.js",
+            },
+            "./blocked": {
+              node: null,
+              default: null,
+            },
+          },
+        }),
+        "src/features/public.js": "export {};",
+        "src/features/private-internal/hidden.js": "export {};",
+      }),
+    );
+
+    assert("entrypoints" in result);
+    assert.deepStrictEqual(Object.keys(result.entrypoints), ["./features/*.js", "./browser"]);
+  });
+});


### PR DESCRIPTION
Core entrypoint discovery was treating `exports` subpaths with `null` targets as real package entrypoints.
This skips blocked targets while still keeping arrays, conditions, and nested objects when at least one branch points to a real target. I added regression coverage and checked it with the core tests passing 56/56, `pnpm tsgo`, `pnpm check-dts`, Prettier, build, and `git diff --check`.
Fixes #242
