### PR TITLE
docs: clarify that --pack only works for npm packages

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -100,6 +100,9 @@ Specify a directory to run `npm pack` in (instead of specifying a tarball filena
 attw --pack .
 ```
 
+Please note that the `--pack` option does not support package managers other than npm at this time.
+Therefore, if you use pnpm or yarn, you should generate the tarball yourself first (using `pnpm pack`/`yarn pack`) and run then run `attw <packed-tarball-name>`, rather than using the `--pack` option.
+
 #### From NPM
 
 Specify the name (and, optionally, version or SemVer range) of a package from the NPM registry instead of a local tarball filename.


### PR DESCRIPTION
This just tweaks the docs to be clear that other package managers generally _won't_ work with `--pack`. Right now, the docs are misleading to me: it just says that it'll run `npm pack`, but doesn't make clear that that might not be what you want. As a person unfamiliar with the minutiae of package publishing, I wasn't sure whether `npm pack` would be fine even in a pnpm/yarn repo... I've since found out it isn't.